### PR TITLE
RHDHPAI-703: Initialize devfile and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Creating an application with a Chatbot code sample
+
+**Note:** The Chatbot code sample uses the **8501** HTTP port.
+
+Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Containerfile` and how they contribute to your build. You can find these files at the following URLs:
+
+* [Chatbot `devfile.yaml`](https://github.com/redhat-appstudio/ai-sample-chatbot-dance/blob/main/devfile.yaml)
+* [Chatbot `Containerfile`](https://github.com/redhat-appstudio/ai-sample-chatbot-dance/blob/main/Containerfile)
+
+1. The `devfile.yaml` file has an [`image-build` component](https://github.com/redhat-appstudio/ai-sample-chatbot-dance/blob/main/devfile.yaml#L21-L27) that points to your `Containerfile`.
+2. The [`Containerfile`](https://github.com/redhat-appstudio/ai-sample-chatbot-dance/blob/main/Containerfile) contains the instructions you need to build the code sample as a container image.
+3. The `devfile.yaml` [`kubernetes-deploy` component](https://github.com/redhat-appstudio/ai-sample-chatbot-dance/blob/main/devfile.yaml#L28-L40) points to a `deploy.yaml` file that contains instructions for deploying the built container image.
+4. The `devfile.yaml` [`deploy` command](https://github.com/redhat-appstudio/ai-sample-chatbot-dance/blob/main/devfile.yaml#L48-L55) completes the [outerloop](https://devfile.io/docs/2.2.2/innerloop-vs-outerloop) deployment phase by pointing to the `image-build` and `kubernetes-deploy` components to create your application.
+
+### Additional resources
+* For more information about the Chatbot AI Sample, see [redhat-ai-dev/ai-lab-samples repository](https://github.com/redhat-ai-dev/ai-lab-samples) or [Chatbot application document](https://github.com/redhat-ai-dev/ai-lab-template/blob/main/templates/chatbot/docs/application.md).
+* For more information about devfiles, see [Devfile.io](https://devfile.io/).
+* For more information about Containerfiles, see [Containerfile reference](https://github.com/containers/common/blob/main/docs/Containerfile.5.md).

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,38 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: my-chatbot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chatbot-app
+  template:
+    metadata:
+      labels:
+        app: chatbot-app
+    spec:
+      containers:
+        - name: my-chatbot
+          image: chatbot-image:latest
+          ports:
+            - name: http
+              containerPort: 8501
+              protocol: TCP
+          resources:
+            requests:
+              memory: "50Mi"
+              cpu: "10m"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-chatbot
+spec:
+  ports:
+    - name: http-8501
+      port: 8501
+      protocol: TCP
+      targetPort: 8501
+  selector:
+    app: chatbot-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 2.2.2
+metadata:
+  name: chatbot
+  projectType: Python
+  displayName: Chatbot Application - Trusted Application Pipeline
+  description: Build your own Large Language Model (LLM)-enabled chat application. Attach your own model server. This sample demonstrates software supply chain security functionality using an advanced continuous integration pipeline covering building, CVE scanning, security scanning, signatures, attestations, SLSA provenance and SBOM along with Gitops-based continuous deployment.
+  language: Python
+  version: 0.0.1
+  provider: Red Hat
+  tags:
+    - ai
+    - llamacpp
+    - vllm
+    - python
+    - sscs
+    - sbom
+    - acs
+  attributes:
+    alpha.dockerimage-port: 8501
+components:
+  - name: image-build
+    image:
+      imageName: chatbot-image:latest
+      dockerfile:
+        uri: Containerfile
+        buildContext: .
+        rootRequired: false
+  - name: kubernetes-deploy
+    attributes:
+      deployment/replicas: 1
+      deployment/cpuRequest: 10m
+      deployment/memoryRequest: 50Mi
+      deployment/container-port: 8501
+    kubernetes:
+      uri: deploy.yaml
+      endpoints:
+        - name: http-8501
+          targetPort: 8501
+          path: /
+          secure: true
+commands:
+  - id: build-image
+    apply:
+      component: image-build
+  - id: deployk8s
+    apply:
+      component: kubernetes-deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHDHPAI-703

## Add Devfile

Adds a devfile and `deploy.yaml` Kubernetes resource file to build and deploy AI sample on various [outerloop](https://devfile.io/docs/2.2.2/innerloop-vs-outerloop#what-is-outerloop) devfile consumers including RHTAP.

## Add README

Adds a simple README file that mirrors template for other devfile samples (e.g. [Python](https://github.com/redhat-appstudio/devfile-sample-python-dance/blob/main/README.md)), also includes pointers to specific resources used under this sample including upstream sources.