### PR TITLE
RHDHPAI-783: Use standard port 8080

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,5 +4,6 @@ COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /chat/requirements.txt
 COPY chatbot_ui.py .
-EXPOSE 8501
+EXPOSE 8080
+ENV STREAMLIT_SERVER_PORT=8080
 ENTRYPOINT [ "streamlit", "run", "chatbot_ui.py" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Creating an application with a Chatbot code sample
 
-**Note:** The Chatbot code sample uses the **8501** HTTP port.
+**Note:** The Chatbot code sample uses the **8080** HTTP port.
 
 Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Containerfile` and how they contribute to your build. You can find these files at the following URLs:
 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           image: chatbot-image:latest
           ports:
             - name: http
-              containerPort: 8501
+              containerPort: 8080
               protocol: TCP
           resources:
             requests:
@@ -30,9 +30,9 @@ metadata:
   name: my-rhtap-chatbot
 spec:
   ports:
-    - name: http-8501
-      port: 8501
+    - name: http-8080
+      port: 8080
       protocol: TCP
-      targetPort: 8501
+      targetPort: 8080
   selector:
     app: rhtap-chatbot-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -16,7 +16,7 @@ metadata:
     - sbom
     - acs
   attributes:
-    alpha.dockerimage-port: 8501
+    alpha.dockerimage-port: 8080
 components:
   - name: image-build
     image:
@@ -30,12 +30,12 @@ components:
       deployment/replicas: 1
       deployment/cpuRequest: 10m
       deployment/memoryRequest: 50Mi
-      deployment/container-port: 8501
+      deployment/container-port: 8080
     kubernetes:
       uri: deploy.yaml
       endpoints:
-        - name: http-8501
-          targetPort: 8501
+        - name: http-8080
+          targetPort: 8080
           path: /
           secure: true
 commands:


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHDHPAI-783

## Fixes port mismatch with the RHTAP bootstrap application

Fixes port mismatch with the RHTAP bootstrap application by using the same standard port 8080 used for the Chatbot application.